### PR TITLE
[Fix] Change to_svg/save_svg to relative utils import

### DIFF
--- a/asterix.py
+++ b/asterix.py
@@ -64,7 +64,7 @@ class State(core.State):
         scale: Optional[float] = None,
     ) -> str:
         del color_theme, scale
-        from pgx_minatar.utils import visualize_minatar
+        from .utils import visualize_minatar
 
         return visualize_minatar(self)
 
@@ -75,7 +75,7 @@ class State(core.State):
         color_theme: Optional[Literal["light", "dark"]] = None,
         scale: Optional[float] = None,
     ) -> None:
-        from pgx_minatar.utils import visualize_minatar
+        from .utils import visualize_minatar
 
         visualize_minatar(self, filename)
 

--- a/breakout.py
+++ b/breakout.py
@@ -59,7 +59,7 @@ class State(core.State):
         scale: Optional[float] = None,
     ) -> str:
         del color_theme, scale
-        from pgx_minatar.utils import visualize_minatar
+        from .utils import visualize_minatar
 
         return visualize_minatar(self)
 
@@ -70,7 +70,7 @@ class State(core.State):
         color_theme: Optional[Literal["light", "dark"]] = None,
         scale: Optional[float] = None,
     ) -> None:
-        from pgx_minatar.utils import visualize_minatar
+        from .utils import visualize_minatar
 
         visualize_minatar(self, filename)
 

--- a/freeway.py
+++ b/freeway.py
@@ -53,7 +53,7 @@ class State(core.State):
         scale: Optional[float] = None,
     ) -> str:
         del color_theme, scale
-        from pgx_minatar.utils import visualize_minatar
+        from .utils import visualize_minatar
 
         return visualize_minatar(self)
 
@@ -64,7 +64,7 @@ class State(core.State):
         color_theme: Optional[Literal["light", "dark"]] = None,
         scale: Optional[float] = None,
     ) -> None:
-        from pgx_minatar.utils import visualize_minatar
+        from .utils import visualize_minatar
 
         visualize_minatar(self, filename)
 

--- a/seaquest.py
+++ b/seaquest.py
@@ -76,7 +76,7 @@ class State(core.State):
         scale: Optional[float] = None,
     ) -> str:
         del color_theme, scale
-        from pgx_minatar.utils import visualize_minatar
+        from .utils import visualize_minatar
 
         return visualize_minatar(self)
 
@@ -87,7 +87,7 @@ class State(core.State):
         color_theme: Optional[Literal["light", "dark"]] = None,
         scale: Optional[float] = None,
     ) -> None:
-        from pgx_minatar.utils import visualize_minatar
+        from .utils import visualize_minatar
 
         visualize_minatar(self, filename)
 

--- a/space_invaders.py
+++ b/space_invaders.py
@@ -63,7 +63,7 @@ class State(core.State):
         scale: Optional[float] = None,
     ) -> str:
         del color_theme, scale
-        from pgx_minatar.utils import visualize_minatar
+        from .utils import visualize_minatar
 
         return visualize_minatar(self)
 
@@ -74,7 +74,7 @@ class State(core.State):
         color_theme: Optional[Literal["light", "dark"]] = None,
         scale: Optional[float] = None,
     ) -> None:
-        from pgx_minatar.utils import visualize_minatar
+        from .utils import visualize_minatar
 
         visualize_minatar(self, filename)
 


### PR DESCRIPTION
The methods `to_svg` and `save_svg` in every environment were using `from pgx_minatar.utils import visualize_minatar`, which does not work anymore when pgx-minatar is installed as a submodule of the pgx package.

This fix changes the import to be relative, which resolves the issue independent of how the package is installed.